### PR TITLE
Fix missing `environment/*` files in NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "sideEffects": false,
   "files": [
     "/index.*",
-    "/environment.*",
+    "/environment/*",
     "/restricted/*",
     "/internals/*",
     "/builders/*",


### PR DESCRIPTION
NPM is missing these files, referenced by e.g. `restricted/reviewed.js`, causing errors like:

```
./node_modules/safevalues/restricted/reviewed.js:5:0-28 - Error: Module not found: Error: Can't resolve '../environment/dev' in '/usr/local/google/home/pgschwendtner/projects/angular/aio/node_modules/safevalues/restricted'
```