### PR TITLE
fix: allow consumption of ESM version of package

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,25 @@
     "registry":"https://wombat-dressing-room.appspot.com"
   },
   "main": "index.js",
+  "module": "index.mjs",
   "types": "index.d.ts",
-  "type": "commonjs",
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "import": "./index.mjs",
+      "types": "./index.d.ts"      
+    },
+    "./restricted/*": {
+      "require": "./restricted/*.js",
+      "import": "./restricted/*.mjs",
+      "types": "./restricted/*.d.ts"
+    },
+    "./dom": {
+      "require": "./dom/index.js",
+      "import": "./dom/index.mjs",
+      "types": "./dom/index.d.ts"      
+    }
+  },
   "sideEffects": false,
   "files": [
     "/index.*",


### PR DESCRIPTION
While this package is distrusted in both ESM and CJS format, the package manifest is not setup to allow ESM consumption. This change does that.

This change is also important when using this package in web environments to allow better dead-code elimination. As OSS bundlers and minifiers do not particularly handle CJS deadcode elimination and tree-shaking well. 

This change reduces the our application size by 14.84Kb